### PR TITLE
BUG: Missing include header in hxx files

### DIFF
--- a/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -23,6 +23,8 @@
 #ifndef itkAnisotropicDiffusionLBRImageFilter_hxx
 #define itkAnisotropicDiffusionLBRImageFilter_hxx
 
+#include "itkAnisotropicDiffusionLBRImageFilter.h"
+
 namespace itk
 {
 

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -28,7 +28,7 @@
 #include "itkMinimumMaximumImageCalculator.h"
 #include "itkCastImageFilter.h"
 #include "itkExtractImageFilter.h"
-
+#include "itkLinearAnisotropicDiffusionLBRImageFilter.h"
 #include "itkUnaryFunctorWithIndexImageFilter.h"
 #include "itkTernaryFunctorImageFilter.h"
 


### PR DESCRIPTION
itkAnisotropicDiffusionLBRImageFilter.hxx and
itkLinearAnisotropicDiffusionLBRImageFilter.hxx did not include their
respective header files. The automatically generated test created
by BuildHeaderTest.py AnisotropicDiffusionLBRHeaderTest1.cxx was not compiling
as it includes the "hxx" files instead of the "h" files when the former are
available.