### PR TITLE
COMP: Add missing COMPONENTS to find_package example call

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,11 @@ cmake_minimum_required(VERSION 2.8)
 
 project(AnisotropicDiffusionLBR_Examples)
 
-find_package(ITK REQUIRED)
+find_package(ITK REQUIRED
+  COMPONENTS
+    AnisotropicDiffusionLBR
+    ITKIOPNG
+    )
 include(${ITK_USE_FILE})
 
 


### PR DESCRIPTION
We need to explicitly specify the module in the COMPONENTS argument to
find_package(ITK when it is a remote module.

Addresses:

  Cannot open include file: 'CoherenceEnhancingDiffusionFilter.h'