### PR TITLE
COMP: Add missing ImageToImageFilter base class #include

### DIFF
--- a/include/itkUnaryFunctorWithIndexImageFilter.h
+++ b/include/itkUnaryFunctorWithIndexImageFilter.h
@@ -26,12 +26,15 @@
 #include "itkImageRegionConstIteratorWithIndex.h"
 #include "itkImageScanlineIterator.h"
 #include "itkAnisotropicDiffusionLBRMacro.h"
-/** A (simplification of) UnaryFunctorImageFilter, which provides the pixel index to the functor.
- */
+#include "itkImageToImageFilter.h"
 
 namespace itk
 {
 
+/** \class UnaryFunctorWithIndexImageFilter
+ *
+ * \brief A (simplification of) UnaryFunctorImageFilter, which provides the pixel index to the functor.
+ */
 template<typename TInputImage, typename TOutputImage, typename TFunctor>
 class UnaryFunctorWithIndexImageFilter:
   public ImageToImageFilter<TInputImage, TOutputImage>


### PR DESCRIPTION
To address:

  ITK-src/Modules/Remote/AnisotropicDiffusionLBR/include/itkUnaryFunctorWithIndexImageFilter.h:37:28:
  error: expected template-name before '<' token