### PR TITLE
COMP: Move ITK_DISALLOW_COPY_AND_ASSIGN calls to public section.

### DIFF
--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
@@ -48,6 +48,8 @@ class LinearAnisotropicDiffusionLBRImageFilter:
   public ImageToImageFilter< TImage, TImage >
 {
 public:
+  ITK_DISALLOW_COPY_AND_ASSIGN(LinearAnisotropicDiffusionLBRImageFilter);
+
   /** Standard class type alias. */
   using Self = LinearAnisotropicDiffusionLBRImageFilter;
   using Superclass = ImageToImageFilter< TImage, TImage >;
@@ -141,9 +143,6 @@ protected:
   using VectorType = Vector<ScalarType,Dimension>;
   static ScalarType ScalarProduct(const TensorType &, const VectorType &, const VectorType &);
 
-private:
-  LinearAnisotropicDiffusionLBRImageFilter(const Self &); //purposely not implemented
-  void operator=(const Self &);  //purposely not implemented
 };
 } // end namespace itk
 


### PR DESCRIPTION
Move `ITK_DISALLOW_COPY_AND_ASSIGN` calls to public section following
the discussion in
https://discourse.itk.org/t/noncopyable

If legacy (pre-macro) copy and assing methods existed, subsitute them
for the `ITK_DISALLOW_COPY_AND_ASSIGN` macro.