### PR TITLE
BUG: Fix test errors steming from the new multi-threading mechanism.

### DIFF
--- a/include/itkUnaryFunctorWithIndexImageFilter.h
+++ b/include/itkUnaryFunctorWithIndexImageFilter.h
@@ -60,14 +60,15 @@ public:
   GetSetFunctorMacro(Functor, FunctorType);
 
 protected:
-  UnaryFunctorWithIndexImageFilter(){}
+  UnaryFunctorWithIndexImageFilter()
+    { this->DynamicMultiThreadingOn(); }
 
   FunctorType m_Functor;
 
   using InputRegionType = typename InputImageType::RegionType;
   using OutputRegionType = typename OutputImageType::RegionType;
 
-  void ThreadedGenerateData(const OutputRegionType & region, ThreadIdType) override
+  void DynamicThreadedGenerateData(const OutputRegionType & region) override
   {
     if( region.GetSize()[0] == 0 )
       {


### PR DESCRIPTION
Fix errors steming from the use of the new `itk::PoolMultiThreader`
class for multi-threading.

The errors stemmed when this gerrit topic got merged:
http://review.source.kitware.com/#/c/23175/

And were later related to the following gerrit-topic:
http://review.source.kitware.com/#/c/23434/

The solution adopted in this patch set was based on the proposal in:
http://review.source.kitware.com/#/c/23439/