### PR TITLE
STYLE: Prefer error checked std::sto[id] over ato[if].

### DIFF
--- a/include/CoherenceEnhancingDiffusionCommandLine.h
+++ b/include/CoherenceEnhancingDiffusionCommandLine.h
@@ -154,14 +154,14 @@ int Execute(int argc, char * argv[])
   int argIndex = 3;
   if( argIndex < argc )
     {
-    const double diffusionTime = atof(argv[argIndex++]);
+    const double diffusionTime = std::stod(argv[argIndex++]);
     if(diffusionTime==0) itkGenericExceptionMacro("Error: Unrecognized diffusion time (third argument).\n");
     diffusionFilter->SetDiffusionTime(diffusionTime);
     }
 
   if( argIndex < argc )
     {
-    const double lambda = atof(argv[argIndex++]);
+    const double lambda = std::stod(argv[argIndex++]);
     if(lambda==0.) itkGenericExceptionMacro("Error: Unrecognized lambda (fourth argument).\n");
     diffusionFilter->SetLambda(lambda);
     }
@@ -185,21 +185,21 @@ int Execute(int argc, char * argv[])
 
   if( argIndex < argc )
     {
-    const double noiseScale = atof(argv[argIndex++]);
+    const double noiseScale = std::stod(argv[argIndex++]);
     if(noiseScale==0.) itkGenericExceptionMacro("Error: Unrecognized noiseScale (sixth argument).\n");
     diffusionFilter->SetNoiseScale(noiseScale);
     }
 
   if( argIndex < argc )
     {
-    const double featureScale = atof(argv[argIndex++]);
+    const double featureScale = std::stod(argv[argIndex++]);
     if(featureScale==0.) itkGenericExceptionMacro("Error: Unrecognized featureScale (seventh argument).\n");
     diffusionFilter->SetFeatureScale(featureScale);
     }
 
   if( argIndex < argc )
     {
-    const double exponent = atof(argv[argIndex++]);
+    const double exponent = std::stod(argv[argIndex++]);
     if(exponent==0.) itkGenericExceptionMacro("Error: Unrecognized exponent (eighth argument).\n");
     diffusionFilter->SetExponent(exponent);
     }

--- a/include/LinearAnisotropicDiffusionCommandLine.h
+++ b/include/LinearAnisotropicDiffusionCommandLine.h
@@ -153,7 +153,7 @@ int Execute(int argc, char * argv[]){
     tensorReader->SetFileName(tensorImageFileName);
 
     // Import diffusion time
-    const double diffusionTime = atof(argv[2+1]);
+    const double diffusionTime = std::stod(argv[2+1]);
     if(diffusionTime==0) itkGenericExceptionMacro("Error: Unrecognized diffusion time (third argument).\n");
 
     // Import output image filename
@@ -168,13 +168,13 @@ int Execute(int argc, char * argv[]){
 
     int argIndex = 4+1;
     if(argIndex<argc){
-        const double ratioToMaxStableTimeStep = atof(argv[argIndex++]);
+        const double ratioToMaxStableTimeStep = std::stod(argv[argIndex++]);
         if(ratioToMaxStableTimeStep==0) itkGenericExceptionMacro("Error: Unrecognized RatioToMaxStableTimeStep (fourth argument).\n");
         diffusionFilter->SetRatioToMaxStableTimeStep(ratioToMaxStableTimeStep);
     }
 
     if(argIndex<argc){
-        const int maxNumberOfTimeSteps = atoi(argv[argIndex++]);
+        const int maxNumberOfTimeSteps = std::stoi(argv[argIndex++]);
         if(maxNumberOfTimeSteps==0) itkGenericExceptionMacro("Error: Unrecognized maxNumberOfTimeSteps (fifth argument).\n");
         diffusionFilter->SetMaxNumberOfTimeSteps(maxNumberOfTimeSteps);
     } else


### PR DESCRIPTION
The `ato[if]` functions do not provide mechanisms for distinguishing
between `0` and the error condition where the input can not be converted.

`std::sto[id]` provides exception handling and detects when an invalid
string attempts to be converted to an [integer|double].

`ato[if]()`
 - **Con**: No error handling.
 - **Con**: Handle neither hexadecimal nor octal.

The use of `ato[if]` in code can cause it to be subtly broken.
`ato[if]` makes two very big assumptions indeed:
 - The string represents an integer/floating point value.
 - The integer can fit into an int.

In agreement with:
http://review.source.kitware.com/#/c/23738/