### PR TITLE
ENH: Allow building examples.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,3 +8,5 @@ if(NOT ITK_SOURCE_DIR)
 else()
   itk_module_impl()
 endif()
+
+itk_module_examples()


### PR DESCRIPTION
Use the ITK CMake macros to build the examples module.