### PR TITLE
COMP: Fix compiler warnings

### DIFF
--- a/include/itkAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.h
@@ -62,10 +62,11 @@ public:
   using PixelType = typename ImageType::PixelType;
   using ScalarType = TScalar;
 
-  static const unsigned int Dimension = ImageType::ImageDimension;
+  using ImageDimensionType = typename ImageType::ImageDimensionType;
+  static constexpr ImageDimensionType ImageDimension = ImageType::ImageDimension;
 
-  using TensorType = SymmetricSecondRankTensor< ScalarType, Dimension >;
-  using TensorImageType = Image< TensorType, Dimension >;
+  using TensorType = SymmetricSecondRankTensor< ScalarType, ImageDimension >;
+  using TensorImageType = Image< TensorType, ImageDimension >;
 
   using StructureTensorFilterType = StructureTensorImageFilter<ImageType, TensorImageType>;
   using LinearDiffusionFilterType = LinearAnisotropicDiffusionLBRImageFilter<ImageType, ScalarType>;

--- a/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -54,7 +54,7 @@ AnisotropicDiffusionLBRImageFilter< TImage, TScalar >
 
   //        const SpacingType unitSpacing(1); // Better below for non-uniform spacing.
   double minSpacing = referenceSpacing[0];
-  for( unsigned int i = 1; i < Dimension; ++i )
+  for( ImageDimensionType i = 1; i < ImageDimension; ++i )
     {
     minSpacing = std::min(minSpacing,referenceSpacing[i]);
     }
@@ -108,8 +108,8 @@ struct AnisotropicDiffusionLBRImageFilter< TImage, TScalar >
       S.ComputeEigenAnalysis(eigenValues,eigenVectors);
 
       // For convenience, eigenvalues are sorted by increasing order
-      Vector<int,Dimension> order;
-      for(int i=0; i<(int)Dimension; ++i) order[i]=i;
+      Vector<int, ImageDimension> order;
+      for(ImageDimensionType i=0; i < ImageDimension; ++i) order[i]=i;
 
       OrderingType ordering(eigenValues);
 
@@ -119,7 +119,7 @@ struct AnisotropicDiffusionLBRImageFilter< TImage, TScalar >
       EigenValuesArrayType ev = this->eigenValuesFunctor->EigenValuesTransform(eigenValues);
 
       TensorType DiffusionTensor;
-      for(int i=0; i<(int)Dimension; ++i){
+      for(ImageDimensionType i=0; i < ImageDimension; ++i){
           DiffusionTensor(order[i],order[i]) = ev[i];
           for(int j=0; j<i; ++j) DiffusionTensor(i,j) = 0.;
       }

--- a/include/itkCoherenceEnhancingDiffusionImageFilter.h
+++ b/include/itkCoherenceEnhancingDiffusionImageFilter.h
@@ -78,7 +78,8 @@ public:
   /** Run-time type information (and related methods). */
   itkTypeMacro(CoherenceEnhancingDiffusionImageFilter, AnisotropicDiffusionLBRImageFilter);
 
-  static const unsigned int Dimension = Superclass::Dimension;
+  using InputImageDimensionType = typename Superclass::InputImageType::ImageDimensionType;
+  static constexpr InputImageDimensionType InputImageDimension = Superclass::InputImageType::ImageDimension;
 
   using EigenValuesArrayType = typename Superclass::EigenValuesArrayType;
   EigenValuesArrayType EigenValuesTransform(const EigenValuesArrayType &) const override;

--- a/include/itkCoherenceEnhancingDiffusionImageFilter.hxx
+++ b/include/itkCoherenceEnhancingDiffusionImageFilter.hxx
@@ -41,14 +41,14 @@ CoherenceEnhancingDiffusionImageFilter< TImage, TScalar >
 ::EigenValuesTransform(const EigenValuesArrayType & ev0) const
 {
   const ScalarType evMin = ev0[0];
-  const ScalarType evMax = ev0[Dimension-1];
+  const ScalarType evMax = ev0[InputImageDimension-1];
 
   EigenValuesArrayType ev;
   switch(m_Enhancement)
     {
         // Weickert's filter.
     case CED:
-        for( unsigned int i = 0; i < Dimension; ++i )
+        for( InputImageDimensionType i = 0; i < InputImageDimension; ++i )
           {
           ev[i] = g_CED(evMax-ev0[i]);
           }
@@ -56,7 +56,7 @@ CoherenceEnhancingDiffusionImageFilter< TImage, TScalar >
 
         // A variance, requiring stronger coherence.
     case cCED:
-        for( unsigned int i = 0; i < Dimension; ++i )
+        for( InputImageDimensionType i = 0; i < InputImageDimension; ++i )
           {
           ev[i] = g_CED( (evMax-ev0[i])/(1.+ev0[i]/m_Lambda) );
           }
@@ -64,7 +64,7 @@ CoherenceEnhancingDiffusionImageFilter< TImage, TScalar >
 
         // Weickert's filter.
     case EED:
-        for( unsigned int i = 0; i < Dimension; ++i )
+        for( InputImageDimensionType i = 0; i < InputImageDimension; ++i )
           {
           ev[i] = g_EED(ev0[i]-evMin);
           }
@@ -72,7 +72,7 @@ CoherenceEnhancingDiffusionImageFilter< TImage, TScalar >
 
         // A variant, promoting diffusion in at least one direction at each point.
     case cEED:
-        for( unsigned int i = 0; i < Dimension; ++i )
+        for( InputImageDimensionType i = 0; i < InputImageDimension; ++i )
           {
           ev[i] = g_EED(ev0[i]);
           }
@@ -80,7 +80,7 @@ CoherenceEnhancingDiffusionImageFilter< TImage, TScalar >
 
         // Isotropic tensors, closely related to Perona-Malik's approach.
     case Isotropic:
-        for( unsigned int i = 0; i < Dimension; ++i )
+        for( InputImageDimensionType i = 0; i < InputImageDimension; ++i )
           {
           ev[i] = g_EED(evMax);
           }

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
@@ -65,12 +65,13 @@ public:
   using ImageType = TImage;
   using PixelType = typename ImageType::PixelType;
 
-  static constexpr unsigned int Dimension = ImageType::ImageDimension;
+  using ImageDimensionType = typename ImageType::ImageDimensionType;
+  static constexpr ImageDimensionType ImageDimension = ImageType::ImageDimension;
 
   using ScalarType = TScalar;
-  using TensorType = SymmetricSecondRankTensor< ScalarType, Dimension >;
-  using TensorImageType = Image< TensorType, Dimension >;
-  using RegionType = ImageRegion< Dimension >;
+  using TensorType = SymmetricSecondRankTensor< ScalarType, ImageDimension >;
+  using TensorImageType = Image< TensorType, ImageDimension >;
+  using RegionType = ImageRegion< ImageDimension >;
 
   void SetInputImage(const ImageType* image);
   void SetInputTensor(const TensorImageType* tensorImage);
@@ -94,14 +95,14 @@ protected:
   typename ImageType::ConstPointer GetInputImage();
   typename TensorImageType::ConstPointer GetInputTensor();
 
-  using IndexType = Index<Dimension>;
+  using IndexType = Index<ImageDimension>;
 
   // ******* Containers for the stencils used in the discretization
-  static const unsigned int HalfStencilSize = (Dimension == 2) ? 3 : 6;
+  static const unsigned int HalfStencilSize = (ImageDimension == 2) ? 3 : 6;
   static const unsigned int StencilSize = 2 * HalfStencilSize;
 
   using StencilCoefficientsType = Vector<ScalarType,HalfStencilSize>;
-  using OffsetType = Offset<Dimension>;
+  using OffsetType = Offset<ImageDimension>;
   using StencilOffsetsType = Vector<OffsetType, HalfStencilSize>;
 
   using InternalSizeT = int;
@@ -114,10 +115,10 @@ protected:
   virtual void ImageUpdateLoop(); /// Automatically called by GenerateData
 
   using StencilType = std::pair< StencilBufferIndicesType, StencilCoefficientsType >;
-  using StencilImageType = Image< StencilType, Dimension >;
+  using StencilImageType = Image< StencilType, ImageDimension >;
   typename StencilImageType::Pointer m_StencilImage;
 
-  using ScalarImageType = Image<ScalarType,Dimension>;
+  using ScalarImageType = Image<ScalarType, ImageDimension>;
   typename ScalarImageType::Pointer m_DiagonalCoefficients;
 
   virtual ScalarType MaxStableTimeStep();
@@ -140,7 +141,7 @@ protected:
   struct StencilFunctor;
   struct FunctorType;
 
-  using VectorType = Vector<ScalarType,Dimension>;
+  using VectorType = Vector<ScalarType, ImageDimension>;
   static ScalarType ScalarProduct(const TensorType &, const VectorType &, const VectorType &);
 
 };

--- a/include/itkStructureTensorImageFilter.h
+++ b/include/itkStructureTensorImageFilter.h
@@ -65,13 +65,15 @@ public:
   /// Run-time type information (and related methods).
   itkTypeMacro(StructureTensorImageFilter, Superclass);
 
+  using InputImageDimensionType = typename Superclass::InputImageType::ImageDimensionType;
+  static constexpr InputImageDimensionType InputImageDimension = Superclass::InputImageType::ImageDimension;
+
   using ImageType = TImage;
   using PixelType = typename ImageType::PixelType;
-  static const unsigned int Dimension =       ImageType::ImageDimension;
   using TensorImageType = TTensorImage;
   using TensorType = typename TensorImageType::PixelType;
   using ScalarType = typename TensorType::ComponentType;
-  using ScalarImageType = Image<ScalarType, Dimension>;
+  using ScalarImageType = Image<ScalarType, InputImageDimension>;
 
   ///Parameter \f$\sigma\f$ of the structure tensor definition.
   itkSetMacro(NoiseScale, ScalarType);
@@ -102,17 +104,17 @@ protected:
   void IntermediateFilter( const Dispatch< false > & );
   typename TensorImageType::Pointer m_IntermediateResult;
 
-  using CovariantVectorType = CovariantVector<ScalarType,Dimension>;
-  using CovariantImageType = Image<CovariantVectorType,Dimension>;
+  using CovariantVectorType = CovariantVector<ScalarType, InputImageDimension>;
+  using CovariantImageType = Image<CovariantVectorType, InputImageDimension>;
 
   struct OuterFunctor
   {
     TensorType operator()(const CovariantVectorType & u) const
       {
       TensorType m;
-      for( unsigned int i = 0; i < Dimension; ++i )
+      for( InputImageDimensionType i = 0; i < InputImageDimension; ++i )
         {
-        for( unsigned int j = i; j < Dimension; ++j)
+        for( InputImageDimensionType j = i; j < InputImageDimension; ++j)
           {
           m(i,j) = u[i]*u[j];
           }


### PR DESCRIPTION
Fix compiler warnings: use the type aliases and image dimensions
constants properly defined in the class header for the image
dimensionality.

Fixes:
```
Modules/Remote/AnisotropicDiffusionLBR/include/
itkLinearAnisotropicDiffusionLBRImageFilter.hxx:108:24:
warning: comparison between signed and unsigned integer expressions
[-Wsign-compare]
      for( auto i = 1; i < Dimension; ++i )
                        ^
```
errors.

reported at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5840769