### PR TITLE
COMP: Fix signed and unsigned integer comparison warnings

### DIFF
--- a/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -121,7 +121,7 @@ struct AnisotropicDiffusionLBRImageFilter< TImage, TScalar >
       TensorType DiffusionTensor;
       for(ImageDimensionType i=0; i < ImageDimension; ++i){
           DiffusionTensor(order[i],order[i]) = ev[i];
-          for(int j=0; j<i; ++j) DiffusionTensor(i,j) = 0.;
+          for(ImageDimensionType j=0; j<i; ++j) DiffusionTensor(i,j) = 0.;
       }
       return DiffusionTensor.Rotate(eigenVectors.GetTranspose());
   }

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -233,7 +233,7 @@ protected:
           for(ImageDimensionType j=0; j<i && same; ++j)
               if( ScalarProduct(D,sb[i],sb[j]) > 0 ){
                   const VectorType u=sb[i], v=sb[j];
-                  for(auto k=0,l=0; k<=ImageDimension; ++k)
+                  for(ImageDimensionType k=0,l=0; k<=ImageDimension; ++k)
                       if(k!=i && k!=j)
                           sb[l++]=sb[k]+u;
                   sb[2]=-u;


### PR DESCRIPTION
Fix signed and unsiged integer comparison warnings.

Fixes:
```
AnisotropicDiffusionLBR/include/itkAnisotropicDiffusionLBRImageFilter.hxx:124:25:
warning: comparison between signed and unsigned integer expressions
[-Wsign-compare]
```

raised at:
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5846916
http://testing.cdash.org/viewBuildError.php?type=1&buildid=5847167