### PR TITLE
COMP: Change enum to new enum class definition

### DIFF
--- a/include/CoherenceEnhancingDiffusionCommandLine.h
+++ b/include/CoherenceEnhancingDiffusionCommandLine.h
@@ -1,4 +1,4 @@
-/*=========================================================================
+ /*=========================================================================
  *
  *  Copyright Insight Software Consortium
  *
@@ -76,7 +76,7 @@ int Execute(int argc, char * argv[])
 
   const char * imageFileName = argv[1];
 
-  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO( imageFileName, itk::ImageIOFactory::ReadMode );
+  itk::ImageIOBase::Pointer imageIO = itk::ImageIOFactory::CreateImageIO( imageFileName, itk::ImageIOFactory::FileModeType::ReadMode );
   if( imageIO.IsNull() )
     {
     std::cerr << "Could not create ImageIO" << std::endl;


### PR DESCRIPTION
Changed to reference new enum class: FileModeType. 

Fixes build errors when ITK is configured with:

- ITK_LEGACY_REMOVE = ON, 

- ITK_FUTURE_LEGACY_REMOVE = ON

Co-Authored-By: Hans Johnson <hans-johnson@uiowa.edu>
