### PR TITLE
COMP: Update to new ITK_DISALLOW_COPY_AND_MOVE macro

### DIFF
--- a/include/itkAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.h
@@ -48,7 +48,7 @@ template <typename TImage, typename TScalar = typename NumericTraits<typename TI
 class AnisotropicDiffusionLBRImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(AnisotropicDiffusionLBRImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(AnisotropicDiffusionLBRImageFilter);
 
   using Self = AnisotropicDiffusionLBRImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;

--- a/include/itkCoherenceEnhancingDiffusionImageFilter.h
+++ b/include/itkCoherenceEnhancingDiffusionImageFilter.h
@@ -65,7 +65,7 @@ template <typename TImage, typename TScalar = typename NumericTraits<typename TI
 class CoherenceEnhancingDiffusionImageFilter : public AnisotropicDiffusionLBRImageFilter<TImage, TScalar>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(CoherenceEnhancingDiffusionImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(CoherenceEnhancingDiffusionImageFilter);
 
   using Self = CoherenceEnhancingDiffusionImageFilter;
   using Superclass = AnisotropicDiffusionLBRImageFilter<TImage, TScalar>;

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
@@ -48,7 +48,7 @@ template <typename TImage, typename TScalar = typename NumericTraits<typename TI
 class LinearAnisotropicDiffusionLBRImageFilter : public ImageToImageFilter<TImage, TImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(LinearAnisotropicDiffusionLBRImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(LinearAnisotropicDiffusionLBRImageFilter);
 
   /** Standard class type alias. */
   using Self = LinearAnisotropicDiffusionLBRImageFilter;

--- a/include/itkStructureTensorImageFilter.h
+++ b/include/itkStructureTensorImageFilter.h
@@ -53,7 +53,7 @@ template <typename TImage,
 class StructureTensorImageFilter : public ImageToImageFilter<TImage, TTensorImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(StructureTensorImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(StructureTensorImageFilter);
 
   using Self = StructureTensorImageFilter;
   using Superclass = ImageToImageFilter<TImage, TImage>;

--- a/include/itkUnaryFunctorWithIndexImageFilter.h
+++ b/include/itkUnaryFunctorWithIndexImageFilter.h
@@ -42,7 +42,7 @@ template <typename TInputImage, typename TOutputImage, typename TFunctor>
 class UnaryFunctorWithIndexImageFilter : public ImageToImageFilter<TInputImage, TOutputImage>
 {
 public:
-  ITK_DISALLOW_COPY_AND_ASSIGN(UnaryFunctorWithIndexImageFilter);
+  ITK_DISALLOW_COPY_AND_MOVE(UnaryFunctorWithIndexImageFilter);
 
   using Self = UnaryFunctorWithIndexImageFilter;
   using Superclass = ImageToImageFilter<TInputImage, TOutputImage>;


### PR DESCRIPTION
Replace the deprecated ITK_DISALLOW_COPY_AND_ASSIGN with
new better descriptive name ITK_DISALLOW_COPY_AND_MOVE.