### PR TITLE
COMP: Remove inclusion of .hxx files as headers

### DIFF
--- a/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -24,7 +24,6 @@
 #ifndef itkAnisotropicDiffusionLBRImageFilter_hxx
 #define itkAnisotropicDiffusionLBRImageFilter_hxx
 
-#include "itkAnisotropicDiffusionLBRImageFilter.h"
 
 namespace itk
 {

--- a/include/itkCoherenceEnhancingDiffusionImageFilter.hxx
+++ b/include/itkCoherenceEnhancingDiffusionImageFilter.hxx
@@ -19,7 +19,6 @@
 #ifndef itkCoherenceEnhancingDiffusionImageFilter_hxx
 #define itkCoherenceEnhancingDiffusionImageFilter_hxx
 
-#include "itkCoherenceEnhancingDiffusionImageFilter.h"
 
 namespace itk
 {

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -29,7 +29,6 @@
 #include "itkMinimumMaximumImageCalculator.h"
 #include "itkCastImageFilter.h"
 #include "itkExtractImageFilter.h"
-#include "itkLinearAnisotropicDiffusionLBRImageFilter.h"
 #include "itkUnaryFunctorWithIndexImageFilter.h"
 #include "itkTernaryFunctorImageFilter.h"
 

--- a/include/itkStructureTensorImageFilter.hxx
+++ b/include/itkStructureTensorImageFilter.hxx
@@ -24,7 +24,6 @@
 #ifndef itkStructureTensorImageFilter_hxx
 #define itkStructureTensorImageFilter_hxx
 
-#include "itkStructureTensorImageFilter.h"
 #include "itkMinimumMaximumImageCalculator.h"
 
 namespace itk


### PR DESCRIPTION
COMP: Remove inclusion of .hxx files as headers

The ability to include either .h or .hxx files as
header files required recursively reading the
.h files twice.  The added complexity is
unnecessary, costly, and can confuse static
analysis tools that monitor header guardes (due
to reaching the maximum depth of recursion
limits for nested #ifdefs in checking).

