### PR TITLE
COMP: Avoid single value vector constructor

### DIFF
--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -477,7 +477,7 @@ LinearAnisotropicDiffusionLBRImageFilter<TImage, TScalar>::ImageUpdate(ScalarTyp
   ImageRegionConstIterator<StencilImageType> stencilIt(m_StencilImage, region);
 
   // Rest of function is a hand-made (sparse matrix)*vector product.
-  m_NextImage->FillBuffer(0.);
+  m_NextImage->FillBuffer({});
 
   // Taking care of Off-Diagonal matrix elements. Cannot be parallelized due to non-local modifications of outputBuffer
   for (inputIt.GoToBegin(), outputIt.GoToBegin(), stencilIt.GoToBegin(); !inputIt.IsAtEnd();


### PR DESCRIPTION
Implicit conversion of a single scalar value to a container (which would
_fill_ the container by the scalar value) is discouraged. With ITK 5.3,
when having `ITK_LEGACY_REMOVE=ON`, the constructors of `Point`,
`RGBPixel`, `RGBAPixel`, and `Vector` that accept a single scalar value
as argument are declared `explicit`. ITK 5.3 has included a preferable
alternative to these constructors:
`itk::MakeFilled<ContainerType>(value)`.