### PR TITLE
COMP: Use modern macro for name of class

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,4 @@
-## This config file is only relevant for clang-format version 8.0.0
+## This config file is only relevant for clang-format version 19.1.4
 ##
 ## Examples of each format style can be found on the in the clang-format documentation
 ## See: https://clang.llvm.org/docs/ClangFormatStyleOptions.html for details of each option
@@ -10,142 +10,309 @@
 ## maintaining a consistent code style.
 ##
 ## EXAMPLE apply code style enforcement before commit:
-#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --modified
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --modified
 ## EXAMPLE apply code style enforcement after commit:
-#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_8.0.0} --last
+#     Utilities/Maintenance/clang-format.bash --clang ${PATH_TO_CLANG_FORMAT_19.1.4} --last
 ---
-# This configuration requires clang-format version 8.0.0 exactly.
-BasedOnStyle: Mozilla
+# This configuration requires clang-format version 19.1.4 exactly.
 Language:        Cpp
 AccessModifierOffset: -2
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: true
-AlignEscapedNewlines: Right
-AlignOperands:   true
-AlignTrailingComments: true
-# clang 9.0 AllowAllArgumentsOnNextLine: true
-# clang 9.0 AllowAllConstructorInitializersOnNextLine: true
+AlignArrayOfStructures: None
+AlignConsecutiveAssignments:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveBitFields:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveDeclarations:
+  Enabled:         true
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    true
+AlignConsecutiveMacros:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveShortCaseStatements:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCaseArrows: false
+  AlignCaseColons: false
+AlignConsecutiveTableGenBreakingDAGArgColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenCondOperatorColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignConsecutiveTableGenDefinitionColons:
+  Enabled:         false
+  AcrossEmptyLines: false
+  AcrossComments:  false
+  AlignCompound:   false
+  AlignFunctionPointers: false
+  PadOperators:    false
+AlignEscapedNewlines: Left
+AlignOperands:   Align
+AlignTrailingComments:
+  Kind:            Always
+  OverEmptyLines:  0
+AllowAllArgumentsOnNextLine: true
 AllowAllParametersOfDeclarationOnNextLine: false
-AllowShortBlocksOnASingleLine: false
+AllowBreakBeforeNoexceptSpecifier: Never
+AllowShortBlocksOnASingleLine: Never
+AllowShortCaseExpressionOnASingleLine: true
 AllowShortCaseLabelsOnASingleLine: false
-AllowShortFunctionsOnASingleLine: Inline
-# clang 9.0 AllowShortLambdasOnASingleLine: All
-# clang 9.0 features AllowShortIfStatementsOnASingleLine: Never
-AllowShortIfStatementsOnASingleLine: false
+AllowShortCompoundRequirementOnASingleLine: true
+AllowShortEnumsOnASingleLine: true
+#AllowShortFunctionsOnASingleLine: Inline Only merge functions defined inside a class. Implies empty.
+#AllowShortFunctionsOnASingleLine: None (in configuration: None) Never merge functions into a single line.
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLambdasOnASingleLine: All
 AllowShortLoopsOnASingleLine: false
 AlwaysBreakAfterDefinitionReturnType: None
-AlwaysBreakAfterReturnType: All
 AlwaysBreakBeforeMultilineStrings: false
-AlwaysBreakTemplateDeclarations: Yes
+AttributeMacros:
+  - __capability
 BinPackArguments: false
 BinPackParameters: false
-BreakBeforeBraces: Custom
+BitFieldColonSpacing: Both
 BraceWrapping:
-  # clang 9.0 feature AfterCaseLabel:  false
+  AfterCaseLabel:  true
   AfterClass:      true
-  AfterControlStatement: true
+  AfterControlStatement: Always
   AfterEnum:       true
+  AfterExternBlock: true
   AfterFunction:   true
   AfterNamespace:  true
   AfterObjCDeclaration: true
   AfterStruct:     true
   AfterUnion:      true
-  AfterExternBlock: true
   BeforeCatch:     true
   BeforeElse:      true
-## This is the big change from historical ITK formatting!
-# Historically ITK used a style similar to https://en.wikipedia.org/wiki/Indentation_style#Whitesmiths_style
-# with indented braces, and not indented code.  This style is very difficult to automatically
-# maintain with code beautification tools.  Not indenting braces is more common among
-# formatting tools.
+  BeforeLambdaBody: false
+  BeforeWhile:     false
   IndentBraces:    false
   SplitEmptyFunction: false
   SplitEmptyRecord: false
   SplitEmptyNamespace: false
-BreakBeforeBinaryOperators: None
-#clang 6.0 BreakBeforeInheritanceComma: true
-BreakInheritanceList: BeforeComma
-BreakBeforeTernaryOperators: true
-#clang 6.0 BreakConstructorInitializersBeforeComma: true
-BreakConstructorInitializers: BeforeComma
+BreakAdjacentStringLiterals: true
+BreakAfterAttributes: Leave
 BreakAfterJavaFieldAnnotations: false
+BreakAfterReturnType: All
+BreakArrays:     true
+BreakBeforeBinaryOperators: None
+BreakBeforeConceptDeclarations: Always
+BreakBeforeBraces: Custom
+BreakBeforeInlineASMColon: OnlyMultiline
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializers: BeforeComma
+BreakFunctionDefinitionParameters: false
+BreakInheritanceList: BeforeComma
 BreakStringLiterals: true
+BreakTemplateDeclarations: Yes
 ## The following line allows larger lines in non-documentation code
 ColumnLimit:     120
 CommentPragmas:  '^ IWYU pragma:'
 CompactNamespaces: false
-ConstructorInitializerAllOnOneLineOrOnePerLine: false
 ConstructorInitializerIndentWidth: 2
 ContinuationIndentWidth: 2
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 DisableFormat:   false
+EmptyLineAfterAccessModifier: Never
+EmptyLineBeforeAccessModifier: LogicalBlock
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
 ForEachMacros:
   - foreach
   - Q_FOREACH
   - BOOST_FOREACH
+IfMacros:
+  - KJ_IF_MAYBE
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
     Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
     Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
   - Regex:           '.*'
     Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
 IncludeIsMainRegex: '(Test)?$'
+IncludeIsMainSourceRegex: ''
+IndentAccessModifiers: false
+IndentCaseBlocks: false
 IndentCaseLabels: true
+IndentExternBlock: AfterExternBlock
+IndentGotoLabels: true
 IndentPPDirectives: AfterHash
+IndentRequiresClause: true
 IndentWidth:     2
 IndentWrappedFunctionNames: false
+InsertBraces:    false
+InsertNewlineAtEOF: false
+InsertTrailingCommas: None
+IntegerLiteralSeparator:
+  Binary:          0
+  BinaryMinDigits: 0
+  Decimal:         0
+  DecimalMinDigits: 0
+  Hex:             0
+  HexMinDigits:    0
 JavaScriptQuotes: Leave
 JavaScriptWrapImports: true
-KeepEmptyLinesAtTheStartOfBlocks: true
+KeepEmptyLines:
+  AtEndOfFile:     false
+  AtStartOfBlock:  true
+  AtStartOfFile:   true
+LambdaBodyIndentation: Signature
+LineEnding:      DeriveLF
 MacroBlockBegin: ''
 MacroBlockEnd:   ''
+MainIncludeChar: Quote
 MaxEmptyLinesToKeep: 2
 NamespaceIndentation: None
 ObjCBinPackProtocolList: Auto
 ObjCBlockIndentWidth: 2
+ObjCBreakBeforeNestedBlockParam: true
 ObjCSpaceAfterProperty: true
 ObjCSpaceBeforeProtocolList: false
+PackConstructorInitializers: BinPack
 PenaltyBreakAssignment: 2
 PenaltyBreakBeforeFirstCallParameter: 19
 PenaltyBreakComment: 300
 ## The following line allows larger lines in non-documentation code
 PenaltyBreakFirstLessLess: 120
+PenaltyBreakOpenParenthesis: 0
+PenaltyBreakScopeResolution: 500
 PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
+PenaltyIndentedWhitespace: 0
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Middle
+PPIndentWidth:   -1
+QualifierAlignment: Custom
+QualifierOrder:
+  - friend
+  - static
+  - inline
+  - constexpr
+  - const
+  - type
+ReferenceAlignment: Pointer
 ReflowComments:  true
+RemoveBracesLLVM: false
+RemoveParentheses: Leave
+RemoveSemicolon: false
+RequiresClausePosition: OwnLine
+RequiresExpressionIndentation: OuterScope
+SeparateDefinitionBlocks: Leave
+ShortNamespaceLines: 1
+SkipMacroDefinitionBody: false
 # We may want to sort the includes as a separate pass
-SortIncludes:    false
+SortIncludes:    Never
+SortJavaStaticImport: Before
 # We may want to revisit this later
-SortUsingDeclarations: false
+SortUsingDeclarations: Never
 SpaceAfterCStyleCast: false
-# SpaceAfterLogicalNot: false
+SpaceAfterLogicalNot: false
 SpaceAfterTemplateKeyword: true
+SpaceAroundPointerQualifiers: Default
 SpaceBeforeAssignmentOperators: true
+SpaceBeforeCaseColon: false
 SpaceBeforeCpp11BracedList: false
 SpaceBeforeCtorInitializerColon: true
 SpaceBeforeInheritanceColon: true
+SpaceBeforeJsonColon: false
 SpaceBeforeParens: ControlStatements
+SpaceBeforeParensOptions:
+  AfterControlStatements: true
+  AfterForeachMacros: true
+  AfterFunctionDefinitionName: false
+  AfterFunctionDeclarationName: false
+  AfterIfMacros:   true
+  AfterOverloadedOperator: false
+  AfterPlacementOperator: true
+  AfterRequiresInClause: false
+  AfterRequiresInExpression: false
+  BeforeNonEmptyParentheses: false
 SpaceBeforeRangeBasedForLoopColon: true
-SpaceInEmptyParentheses: false
+SpaceBeforeSquareBrackets: false
+SpaceInEmptyBlock: false
 SpacesBeforeTrailingComments: 1
-SpacesInAngles:  false
+SpacesInAngles:  Never
 SpacesInContainerLiterals: false
-SpacesInCStyleCastParentheses: false
-SpacesInParentheses: false
+SpacesInLineCommentPrefix:
+  Minimum:         1
+  Maximum:         -1
+SpacesInParens:  Never
+SpacesInParensOptions:
+  ExceptDoubleParentheses: false
+  InCStyleCasts:   false
+  InConditionalStatements: false
+  InEmptyParentheses: false
+  Other:           false
 SpacesInSquareBrackets: false
-Standard:        Cpp11
+Standard:        Latest
+StatementAttributeLikeMacros:
+  - Q_EMIT
 StatementMacros:
   - Q_UNUSED
   - QT_REQUIRE_VERSION
+  - ITK_GCC_PRAGMA_PUSH
+  - ITK_GCC_PRAGMA_POP
+  - ITK_GCC_SUPPRESS_Wfloat_equal
+  - ITK_GCC_SUPPRESS_Wformat_nonliteral
+  - ITK_GCC_SUPPRESS_Warray_bounds
+  - ITK_CLANG_PRAGMA_PUSH
+  - ITK_CLANG_PRAGMA_POP
+  - ITK_CLANG_SUPPRESS_Wzero_as_null_pointer_constant
+  - CLANG_PRAGMA_PUSH
+  - CLANG_PRAGMA_POP
+  - CLANG_SUPPRESS_Wfloat_equal
+  - INTEL_PRAGMA_WARN_PUSH
+  - INTEL_PRAGMA_WARN_POP
+  - INTEL_SUPPRESS_warning_1292
+  - itkTemplateFloatingToIntegerMacro
+  - itkLegacyMacro
+TableGenBreakInsideDAGArg: DontBreak
 TabWidth:        2
 UseTab:          Never
+VerilogBreakBetweenInstancePorts: true
+WhitespaceSensitiveMacros:
+  - BOOST_PP_STRINGIZE
+  - CF_SWIFT_NAME
+  - NS_SWIFT_NAME
+  - PP_STRINGIZE
+  - STRINGIZE
 ...

--- a/.github/workflows/apply-clang-format.yml
+++ b/.github/workflows/apply-clang-format.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - uses: InsightSoftwareConsortium/ITKApplyClangFormatAction@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   cxx-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
+    with:
+      warnings-to-ignore: 'ld. warning. ignoring duplicate libraries. \'-lm\''
 
   python-build-workflow:
     uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2

--- a/.github/workflows/build-test-package.yml
+++ b/.github/workflows/build-test-package.yml
@@ -14,10 +14,10 @@ on:
 
 jobs:
   cxx-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-cxx.yml@v5.4.2
 
   python-build-workflow:
-    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.0
+    uses: InsightSoftwareConsortium/ITKRemoteModuleBuildTestPackageAction/.github/workflows/build-test-package-python.yml@v5.4.2
     with:
       test-notebooks: false
     secrets:

--- a/.github/workflows/clang-format-linter.yml
+++ b/.github/workflows/clang-format-linter.yml
@@ -7,5 +7,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
+
     - uses: InsightSoftwareConsortium/ITKClangFormatLinterAction@master

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.16.3)
 
 project(AnisotropicDiffusionLBR
   VERSION 5.1.0       #Version should track with ITK

--- a/include/itkAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.h
@@ -58,7 +58,7 @@ public:
   /// Method for creation through the object factory.
   itkNewMacro(Self);
   /// Run-time type information (and related methods).
-  itkTypeMacro(AnisotropicDiffusionLBRImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(AnisotropicDiffusionLBRImageFilter);
 
   using ImageType = TImage;
   using PixelType = typename ImageType::PixelType;

--- a/include/itkAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkAnisotropicDiffusionLBRImageFilter.hxx
@@ -141,7 +141,7 @@ struct AnisotropicDiffusionLBRImageFilter<TImage, TScalar>::DiffusionTensorFunct
   }
   const EigenValuesArrayType & e;
   OrderingType(const EigenValuesArrayType & e_)
-    : e(e_){};
+    : e(e_) {};
 };
 
 template <typename TImage, typename TScalar>

--- a/include/itkAnisotropicDiffusionLBRMacro.h
+++ b/include/itkAnisotropicDiffusionLBRMacro.h
@@ -28,13 +28,13 @@
  Getters and setters for functor types, inspired by UnaryFunctorImageFilter.
  No equality test performed for the setter.
  */
-#define GetSetFunctorMacro(name, type)                                                                                 \
-  virtual type &       Get##name() { return this->m_##name; }                                                          \
-  virtual const type & Get##name() const { return this->m_##name; }                                                    \
-  virtual void         Set##name(const type & _arg)                                                                    \
-  {                                                                                                                    \
-    m_##name = _arg;                                                                                                   \
-    this->Modified();                                                                                                  \
+#define GetSetFunctorMacro(name, type)                              \
+  virtual type &       Get##name() { return this->m_##name; }       \
+  virtual const type & Get##name() const { return this->m_##name; } \
+  virtual void         Set##name(const type & _arg)                 \
+  {                                                                 \
+    m_##name = _arg;                                                \
+    this->Modified();                                               \
   }
 
 #endif

--- a/include/itkCoherenceEnhancingDiffusionImageFilter.h
+++ b/include/itkCoherenceEnhancingDiffusionImageFilter.h
@@ -76,7 +76,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(CoherenceEnhancingDiffusionImageFilter, AnisotropicDiffusionLBRImageFilter);
+  itkOverrideGetNameOfClassMacro(CoherenceEnhancingDiffusionImageFilter);
 
   using InputImageDimensionType = typename Superclass::InputImageType::ImageDimensionType;
   static constexpr InputImageDimensionType InputImageDimension = Superclass::InputImageType::ImageDimension;

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.h
@@ -60,7 +60,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(LinearAnisotropicDiffusionLBRImageFilter, ImageToImageFilter);
+  itkOverrideGetNameOfClassMacro(LinearAnisotropicDiffusionLBRImageFilter);
 
   using ImageType = TImage;
   using PixelType = typename ImageType::PixelType;

--- a/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
+++ b/include/itkLinearAnisotropicDiffusionLBRImageFilter.hxx
@@ -153,8 +153,8 @@ public:
           // Neumann boundary conditions.
           *yIndex = this->OutsideBufferIndex();
         } // if y
-      }   // for eps
-    }     // for i
+      } // for eps
+    } // for i
     return stencil;
   }
 
@@ -352,8 +352,8 @@ LinearAnisotropicDiffusionLBRImageFilter<TImage, TScalar>::GenerateStencils()
         diagIt.Value() += coefficient;
         diagBuffer[yIndex] += coefficient;
       } // if y
-    }   // for i
-  }     // for stencilIt, diagIt
+    } // for i
+  } // for stencilIt, diagIt
 }
 
 

--- a/include/itkStructureTensorImageFilter.h
+++ b/include/itkStructureTensorImageFilter.h
@@ -63,7 +63,7 @@ public:
   /// Method for creation through the object factory.
   itkNewMacro(Self);
   /// Run-time type information (and related methods).
-  itkTypeMacro(StructureTensorImageFilter, Superclass);
+  itkOverrideGetNameOfClassMacro(StructureTensorImageFilter);
 
   using InputImageDimensionType = typename Superclass::InputImageType::ImageDimensionType;
   static constexpr InputImageDimensionType InputImageDimension = Superclass::InputImageType::ImageDimension;

--- a/include/itkUnaryFunctorWithIndexImageFilter.h
+++ b/include/itkUnaryFunctorWithIndexImageFilter.h
@@ -53,7 +53,7 @@ public:
   itkNewMacro(Self);
 
   /** Run-time type information (and related methods). */
-  itkTypeMacro(UnaryFunctorWithIndexImageFilter, Superclass);
+  itkOverrideGetNameOfClassMacro(UnaryFunctorWithIndexImageFilter);
 
   using InputImageType = TInputImage;
   using OutputImageType = TOutputImage;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-anisotropicdiffusionlbr"
-version = "2.0.0"
+version = "2.0.1"
 description = "Smooth images while preserving edges or coherent structures."
 readme = "README.rst"
 license = {file = "LICENSE"}
@@ -34,7 +34,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Medical Science Apps.",
     "Topic :: Software Development :: Libraries",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 dependencies = [
     "itk == 5.4.*",
 ]

--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,5 @@
 itk_wrap_module(AnisotropicDiffusionLBR)
-itk_auto_load_submodules()
-itk_end_wrap_module()
+set(WRAPPING_SUBMODULE_ORDER
+  itkAnisotropicDiffusionLBRImageFilter
+  )
+itk_auto_load_and_end_wrap_submodules()

--- a/wrapping/itkCoherenceEnhancingDiffusionImageFilter.wrap
+++ b/wrapping/itkCoherenceEnhancingDiffusionImageFilter.wrap
@@ -1,3 +1,3 @@
-itk_wrap_class("itk::CoherenceEnhancingDiffusionImageFilter" POINTER)
+itk_wrap_class("itk::CoherenceEnhancingDiffusionImageFilter" POINTER_WITH_SUPERCLASS)
   itk_wrap_image_filter("${WRAP_ITK_SCALAR}" 1 "2;3")
 itk_end_wrap_class()


### PR DESCRIPTION
When preparing for the future with ITK by setting
ITK_FUTURE_LEGACY_REMOVE:BOOL=ON
ITK_LEGACY_REMOVEBOOL=ON

The future preferred macro should be used
│ -  itkTypeMacro
│ +  itkOverrideGetNameOfClassMacro

Closes #60.