### PR TITLE
BUG: Ensure itkAnisotropicDiffusionLBRImageFilter wrapped first

### DIFF
--- a/wrapping/CMakeLists.txt
+++ b/wrapping/CMakeLists.txt
@@ -1,3 +1,5 @@
 itk_wrap_module(AnisotropicDiffusionLBR)
-itk_auto_load_submodules()
-itk_end_wrap_module()
+set(WRAPPING_SUBMODULE_ORDER
+  itkAnisotropicDiffusionLBRImageFilter
+  )
+itk_auto_load_and_end_wrap_submodules()


### PR DESCRIPTION
For:

itkCoherenceEnhancingDiffusionImageFilter: warning(4): ITK type not wrapped, or currently not known: itk::AnisotropicDiffusionLBRImageFilter< itk::Image< short >, double >
itkCoherenceEnhancingDiffusionImageFilter: warning(4): ITK type not wrapped, or currently not known:
itk::AnisotropicDiffusionLBRImageFilter< itk::Image< short, 3 >, double
>