### PR TITLE
COMP: Fix compile error due to undeclared dependancy on ITKIOPNG

### DIFF
--- a/itk-module.cmake
+++ b/itk-module.cmake
@@ -10,6 +10,7 @@ itk_module(AnisotropicDiffusionLBR
     ITKIOImageBase
     ITKIOSpatialObjects
     ITKMetaIO
+    ITKIOPNG
     ITKImageGradient
   TEST_DEPENDS
     ITKTestKernel


### PR DESCRIPTION
Closes https://github.com/InsightSoftwareConsortium/ITKAnisotropicDiffusionLBR/issues/67. Recreation of #59.